### PR TITLE
Unique counts

### DIFF
--- a/shape_producer/estimation_methods_2016.py
+++ b/shape_producer/estimation_methods_2016.py
@@ -614,7 +614,11 @@ class WEstimationWithQCD(EstimationMethod):
 
         # Determine extrapolation factors
         R_ss_to_os = wjets_os_cr_count.result/wjets_ss_cr_count.result
-        R_high_to_low_mt_os = wjets_low_mt_os_cr_count.result/wjets_high_mt_os_cr_counts.pop(self._w_process.name).result
+
+        wjets_integral_low_mt_os = wjets_low_mt_os_cr_count.result
+        wjets_integral_high_mt_os = wjets_high_mt_os_cr_counts.pop(self._w_process.name).result
+
+        R_high_to_low_mt_os = wjets_integral_low_mt_os/wjets_integral_high_mt_os
         R_high_to_low_mt_ss = wjets_low_mt_ss_cr_count.result/wjets_high_mt_ss_cr_counts.pop(self._w_process.name).result
         print "SS to OS extrapolation factor:",R_ss_to_os
         print "high to low mt os extrapolation factor:",R_high_to_low_mt_os
@@ -640,11 +644,10 @@ class WEstimationWithQCD(EstimationMethod):
         print "yield in os high mt region:",high_mt_os_yield
 
         # Derive and normalize final shape
-        wjets_integral = wjets_mc_shape.result.Integral()
-        print "MC yield in signal region:",wjets_integral
+        print "MC yield in signal region:",wjets_integral_low_mt_os
+        sf = (high_mt_os_yield - self._qcd_ss_to_os_extrapolation_factor*high_mt_ss_yield)/(R_ss_to_os-self._qcd_ss_to_os_extrapolation_factor)/wjets_integral_high_mt_os
         estimated_yield = R_high_to_low_mt_os*R_ss_to_os*(high_mt_os_yield - self._qcd_ss_to_os_extrapolation_factor*high_mt_ss_yield)/(R_ss_to_os-self._qcd_ss_to_os_extrapolation_factor)
         print "Estimated yield in signal region:",estimated_yield
-        sf = estimated_yield/wjets_integral
         print "Scale wjets by",sf
         wjets_shape = copy.deepcopy(wjets_mc_shape)
         wjets_shape.result.Scale(sf)
@@ -811,8 +814,12 @@ class QCDEstimationWithW(EstimationMethod):
 
         # Determine extrapolation factors
         R_ss_to_os = wjets_os_cr_count.result/wjets_ss_cr_count.result
+
+        wjets_integral_low_mt_ss = wjets_low_mt_ss_cr_count.result
+        wjets_integral_high_mt_ss = wjets_high_mt_ss_cr_counts.pop(self._w_process.name).result
+
         R_high_to_low_mt_os = wjets_low_mt_os_cr_count.result/wjets_high_mt_os_cr_counts.pop(self._w_process.name).result
-        R_high_to_low_mt_ss = wjets_low_mt_ss_cr_count.result/wjets_high_mt_ss_cr_counts.pop(self._w_process.name).result
+        R_high_to_low_mt_ss = wjets_integral_low_mt_ss/wjets_integral_high_mt_ss
         print "SS to OS extrapolation factor:",R_ss_to_os
         print "high to low mt os extrapolation factor:",R_high_to_low_mt_os
         print "high to low mt ss extrapolation factor:",R_high_to_low_mt_ss
@@ -829,11 +836,10 @@ class QCDEstimationWithW(EstimationMethod):
 
         # Derive and normalize final shape for QCD
         wjets_shape = qcd_control_region_shapes.pop(self._w_process.name)
-        wjets_integral = wjets_shape.result.Integral()
-        print "MC yield in qcd control region for wjets:",wjets_integral
+        print "MC yield in qcd control region for wjets:",wjets_integral_low_mt_ss
+        sf = (high_mt_os_yield - self._qcd_ss_to_os_extrapolation_factor*high_mt_ss_yield)/(R_ss_to_os-self._qcd_ss_to_os_extrapolation_factor)/wjets_integral_high_mt_ss
         estimated_yield = R_high_to_low_mt_ss*(high_mt_os_yield - self._qcd_ss_to_os_extrapolation_factor*high_mt_ss_yield)/(R_ss_to_os-self._qcd_ss_to_os_extrapolation_factor)
         print "Estimated yield in qcd control region for wjets:",estimated_yield
-        sf = estimated_yield/wjets_integral
         print "Scale wjets by",sf
         wjets_shape.result.Scale(sf)
 

--- a/shape_producer/estimation_methods_2016.py
+++ b/shape_producer/estimation_methods_2016.py
@@ -838,9 +838,6 @@ class QCDEstimationWithW(EstimationMethod):
         wjets_shape.result.Scale(sf)
 
         qcd_shape = copy.deepcopy(qcd_control_region_shapes.pop(self._data_process.name))
-        print "remaining members of qcd cr shapes:"
-        for sh in qcd_control_region_shapes.values():
-            print sh.name
         qcd_shape.result.Add(wjets_shape.result,-1.0)
         for sh in qcd_control_region_shapes.values():
             qcd_shape.result.Add(sh.result,-1.0)
@@ -850,7 +847,7 @@ class QCDEstimationWithW(EstimationMethod):
         qcd_shape.name = systematic.name
 
         # Replace negative entries by zeros and renormalize shape
-        #qcd_shape.replace_negative_entries_and_renormalize(tolerance=0.1)
+        qcd_shape.replace_negative_entries_and_renormalize(tolerance=0.05)
 
         return qcd_shape
 

--- a/shape_producer/estimation_methods_2017.py
+++ b/shape_producer/estimation_methods_2017.py
@@ -3,10 +3,20 @@
 from cutstring import *
 from estimation_methods import EstimationMethod, SStoOSEstimationMethod, ABCDEstimationMethod
 from estimation_methods_2016 import DataEstimation as DataEstimation2016
+from estimation_methods_2016 import WEstimationWithQCD as WEstimationWithQCD2016
+from estimation_methods_2016 import QCDEstimationWithW as QCDEstimationWithW2016
 from era import log_query
 
 
 class DataEstimation(DataEstimation2016):
+    pass
+
+
+class WEstimationWithQCD(WEstimationWithQCD2016):
+    pass
+
+
+class QCDEstimationWithW(QCDEstimationWithW2016):
     pass
 
 

--- a/shape_producer/histogram.py
+++ b/shape_producer/histogram.py
@@ -223,9 +223,11 @@ def root_object_create_result(root_object):
 class RootObjects(object):
     def __init__(self, output_filename):
         self._root_objects = []
+        self._unique_root_objects = []
         self._counts = []
         self._produced = False
         self._output_filename = output_filename
+        self._duplicate_root_objects = {}
 
     def add(self, root_object):
         if self._produced:
@@ -235,22 +237,44 @@ class RootObjects(object):
             raise Exception
         else:
             if isinstance(root_object, list):
-                for r in root_object:
-                    if r.name in [ro.name for ro in self._root_objects]:
-                        logger.fatal(
-                            "Unable to add root object with name \"%s\" because another one with the same name is already contained",
-                            r.name)
-                        logger.fatal("Already present: %s",
-                                     [ro.name for ro in self._root_objects])
-                        raise KeyError
                 self._root_objects += root_object
             else:
-                if root_object.name in [ro.name for ro in self._root_objects]:
-                    logger.fatal(
-                        "Unable to add root object with name \"%s\" because another one with the same name is already contained",
-                        root_object.name)
-                    raise KeyError
                 self._root_objects.append(root_object)
+
+    def add_unique(self,root_object):
+        if self._produced:
+            logger.fatal(
+                "A produce function has already been called. No more histograms can be added."
+            )
+            raise Exception
+        else:
+            if isinstance(root_object, list):
+                for r in root_object:
+                    unique_names = [ro.name for ro in self._unique_root_objects]
+                    found_duplicate_for = unique_names.index(r.name) if r.name in unique_names else None
+                    if r.name in unique_names:
+                        logger.warning(
+                            "!!! Attention !!! Attempt to add another root object with name \"%s\" !!! Attention !!!",
+                            r.name)
+                        self._duplicate_root_objects.setdefault(r.name,[self._unique_root_objects[found_duplicate_for]]).append(r)
+
+                        logger.warning("Already present for %s: %s",
+                                    r.name,self._duplicate_root_objects[r.name])
+                    else:
+                        self._unique_root_objects.append(r)
+            else:
+                unique_names = [ro.name for ro in self._unique_root_objects]
+                found_duplicate_for = unique_names.index(root_object.name) if root_object.name in unique_names else None
+                if root_object.name in unique_names:
+                    logger.warning(
+                        "!!! Attention !!! Attempt to add another root object with name \"%s\" !!! Attention !!!",
+                        root_object.name)
+                    self._duplicate_root_objects.setdefault(root_object.name,[self._unique_root_objects[found_duplicate_for]]).append(r)
+
+                    logger.warning("Already present for %s: %s",
+                             root_object.name, self._duplicate_root_objects.values[root_object.name])
+                else:
+                    self._unique_root_objects.append(root_object)
 
     def new_histogram(self, **kwargs):
         self.add(Histogram(**kwargs))
@@ -282,7 +306,7 @@ class RootObjects(object):
         self.create_output_file()
         self._produced = True
         # determine how many data frames have to be created; sort by inputfiles and trees
-        files_folders = self.get_combinations(self._root_objects, self._counts)
+        files_folders = self.get_combinations(self._unique_root_objects, self._counts)
 
         for files_folder in files_folders:
             # create the dataframe
@@ -290,7 +314,7 @@ class RootObjects(object):
                 str(files_folder[1]), str(files_folder[0][0]))
             # loop over the corresponding histograms and create an own dataframe for each histogram -> TODO
             for h in [
-                    h for h in self._root_objects
+                    h for h in self._unique_root_objects
                     if h.files_folders() == files_folder
             ]:
                 # find overlapping cut selections -> dummy atm
@@ -299,7 +323,7 @@ class RootObjects(object):
                 h.create_result(dataframe=special_dataframe)
             # create the histograms
             for h in [
-                    h for h in self._root_objects
+                    h for h in self._unique_root_objects
                     if h.files_folders() == files_folder
             ]:
                 h.update()
@@ -309,13 +333,13 @@ class RootObjects(object):
         self.create_output_file()
         self._produced = True
         if num_threads == 1:
-            for ro in self._root_objects:
+            for ro in self._unique_root_objects:
                 ro.create_result()
         else:
             from multiprocessing import Pool
             pool = Pool(processes=num_threads)
             root_objects_new = pool.map(root_object_create_result,
-                                        [ro for ro in self._root_objects])
+                                        [ro for ro in self._unique_root_objects])
             pool.close()
             pool.join()
 
@@ -323,12 +347,21 @@ class RootObjects(object):
             # the result objects have to be copied.
             # Otherwise, the systematic's root_object has no result associated.
             for i_ro in range(len(root_objects_new)):
-                self._root_objects[i_ro]._result = root_objects_new[
+                self._unique_root_objects[i_ro]._result = root_objects_new[
                     i_ro]._result
 
-        for h in self._root_objects:  # write sequentially to prevent race conditions
+        for h in self._unique_root_objects:  # write sequentially to prevent race conditions
             h.save(self._output_tree)
         return self
+
+    def set_duplicates(self):
+        logger.debug("Setting duplicates to the corresponding produced ROOT objects")
+        for ro in self._unique_root_objects:
+            if ro.name in self._duplicate_root_objects:
+                logger.debug("Setting duplicates for %s",ro.name)
+                for dup_ro in self._duplicate_root_objects[ro.name]:
+                    dup_ro._result = ro.result
+                    self._root_objects[self._root_objects.index(dup_ro)]._result = ro.result
 
     def save(self):
         if not self._produced:

--- a/shape_producer/systematics.py
+++ b/shape_producer/systematics.py
@@ -154,9 +154,10 @@ class Systematics(object):
                          systematic.name)
             systematic.create_root_objects()
             self._root_objects_holder.add(systematic.root_objects)
+            self._root_objects_holder.add_unique(systematic.root_objects)
         #self._root_objects_holder.check_duplicates() # TODO: Implement this if needed
 
-        # produce the ROOT objects (in parallel)
+        # produce unique ROOT objects (in parallel)
         logger.debug("Produce ROOT objects using the %s backend.",
                      self._backend)
         if self._backend == "classic":
@@ -166,6 +167,9 @@ class Systematics(object):
         else:
             logger.fatal("Backend %s is not implemented.", self._backend)
             raise Exception
+
+        # set duplicates to the produced ROOT objects
+        self._root_objects_holder.set_duplicates()
 
     # to the actual estimations. Currently do not run in parallel due to expected very low runtime, can in principle be parallelized
     def do_estimations(self):


### PR DESCRIPTION
Hi guys,

As discussed with Stefan, I've enabled the possibility to share count objects among different estimation methods if necessary. This is done by producing these only once (via a list of unique objects) and copying the results into the "empty" objects created with the same name.

This disables of course the check and the following Exception, if multiple objects are found for the same name and for now, only a corresponding warning is printed out.

Advantages of this method are the faster production of control plots which may share the same yield estimations and the possibility to perform a simultaneous WJets & QCD estimation while still using two separate estimation methods for WJets and QCD.

Disadvantage: the user has to pay attention with his category names. For some special cases - e.g. plotting iso_1 and iso_2 for tau-tau ----> different ABCD QCD control regions - the categories should have different names. In the example with tautau; iso_1 has the usual category name, e.g. "tt_inclusive", for iso_2, since a different ABCD selection has to be used, "tt_inclusive_iso_2". Otherwise the yield estimations for MC processes will be shared among iso_1 and iso_2, but this is unwanted.

What do you think about this?

Cheers,

Artur  