### PR TITLE
[2017] Redirect Run2017 era to always most recent setup

### DIFF
--- a/shape_producer/era.py
+++ b/shape_producer/era.py
@@ -69,33 +69,6 @@ class Run2016(Era):
         return files
 
 
-class Run2017(Era):
-    def __init__(self, database_path):
-        super(Run2017, self).__init__(
-            "Run2017", 42.71 * 1000.0, database_path
-        )  # Lumi according to full Run2017 data (Prompt) with normtag
-
-    def data_files(self, channel):
-        query = {
-            "data": True,
-            "campaign": "Run2017(B|C|D|E|F)",
-            "scenario": "PromptRecov(1|2|3)"
-        }
-        if channel.name == "mt":
-            query["process"] = "SingleMuon"
-        elif channel.name == "et":
-            query["process"] = "SingleElectron"
-        elif channel.name == "tt":
-            query["process"] = "Tau"
-        elif channel.name == "em":
-            query["process"] = "MuonEG"
-        else:
-            logger.critical("Channel %s is not implemented.", channel.name)
-        files = self.datasets_helper.get_nicks_with_query(query)
-        log_query(self.name, query, files)
-        return files
-
-
 class Run201712SepRereco(Era):
     def __init__(self, database_path):
         super(Run201712SepRereco, self).__init__("Run201712SepRereco",
@@ -172,3 +145,7 @@ class Run2017ReReco31Mar(Era):
         files = self.datasets_helper.get_nicks_with_query(query)
         log_query(self.name, query, files)
         return files
+
+
+# Redirect Run2017 to most recent setup
+Run2017 = Run2017ReReco31Mar


### PR DESCRIPTION
@ArturAkh @janekbechtel @swozniewski Kommentar dringend benoetigt! Seid ihr damit einverstanden? Das loest das Problem mit Run2017<BlaBla>. Wir redirecten die ReReReReReco einfach zu Run2017 und muessen den Code nicht dauernd aendern.

Ich merge heute gegen abend, sollte sich niemand beschweren (bisschen Zeitdruck).